### PR TITLE
Implement activity capacity waitlist and auto-promotion

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Enforce activity capacity limits
+- Automatically place students on a waitlist when activities are full
+- Auto-promote waitlisted students when a spot opens
 
 ## Getting Started
 
@@ -29,8 +32,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/activities`                                                     | Get all activities with participant and waitlist counts             |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Enroll in an activity or join waitlist if full                      |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from participant list or waitlist                        |
 
 ## Data Model
 
@@ -42,9 +46,18 @@ The application uses a simple data model with meaningful identifiers:
    - Schedule
    - Maximum number of participants allowed
    - List of student emails who are signed up
+   - Ordered waitlist of student emails
+   - Computed counts for participants and waitlist
 
 2. **Students** - Uses email as identifier:
    - Name
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Signup and Waitlist Behavior
+
+- If an activity has available spots, signup returns `status: "enrolled"`.
+- If an activity is full, signup returns `status: "waitlisted"` and a waitlist `position`.
+- If an enrolled student unregisters and the waitlist is not empty, the first waitlisted student is auto-promoted and unregister returns `status: "promoted"`.
+- Duplicate entries are rejected if an email is already enrolled or already on the waitlist for the same activity.

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from copy import deepcopy
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +20,88 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Initial in-memory activity database
+ACTIVITIES_TEMPLATE = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        "waitlist": []
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        "waitlist": []
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        "waitlist": []
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        "waitlist": []
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        "waitlist": []
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        "waitlist": []
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        "waitlist": []
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        "waitlist": []
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        "waitlist": []
     }
 }
+
+activities = deepcopy(ACTIVITIES_TEMPLATE)
+
+
+def _serialize_activity(activity: dict) -> dict:
+    participants = activity.get("participants", [])
+    waitlist = activity.get("waitlist", [])
+    return {
+        "description": activity["description"],
+        "schedule": activity["schedule"],
+        "max_participants": activity["max_participants"],
+        "participants": participants,
+        "participant_count": len(participants),
+        "waitlist": waitlist,
+        "waitlist_count": len(waitlist)
+    }
 
 
 @app.get("/")
@@ -85,7 +111,10 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return {
+        name: _serialize_activity(activity)
+        for name, activity in activities.items()
+    }
 
 
 @app.post("/activities/{activity_name}/signup")
@@ -97,17 +126,29 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+    participants = activity["participants"]
+    waitlist = activity.setdefault("waitlist", [])
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
+    # Validate student is not already signed up or waitlisted
+    if email in participants or email in waitlist:
         raise HTTPException(
             status_code=400,
-            detail="Student is already signed up"
+            detail="Student is already signed up or waitlisted"
         )
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    if len(participants) < activity["max_participants"]:
+        participants.append(email)
+        return {
+            "status": "enrolled",
+            "message": f"Signed up {email} for {activity_name}"
+        }
+
+    waitlist.append(email)
+    return {
+        "status": "waitlisted",
+        "position": len(waitlist),
+        "message": f"{activity_name} is full. Added {email} to the waitlist"
+    }
 
 
 @app.delete("/activities/{activity_name}/unregister")
@@ -119,14 +160,37 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+    participants = activity["participants"]
+    waitlist = activity.setdefault("waitlist", [])
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+    if email in participants:
+        participants.remove(email)
 
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        if waitlist:
+            promoted_email = waitlist.pop(0)
+            participants.append(promoted_email)
+            return {
+                "status": "promoted",
+                "promoted_email": promoted_email,
+                "message": (
+                    f"Unregistered {email} from {activity_name}. "
+                    f"Auto-enrolled {promoted_email} from the waitlist"
+                )
+            }
+
+        return {
+            "status": "unregistered",
+            "message": f"Unregistered {email} from {activity_name}"
+        }
+
+    if email in waitlist:
+        waitlist.remove(email)
+        return {
+            "status": "unregistered_waitlist",
+            "message": f"Removed {email} from the waitlist for {activity_name}"
+        }
+
+    raise HTTPException(
+        status_code=400,
+        detail="Student is not signed up or waitlisted for this activity"
+    )

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,18 +12,18 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - details.participant_count;
 
         // Create participants HTML with delete icons instead of bullet points
         const participantsHTML =
-          details.participants.length > 0
+          details.participant_count > 0
             ? `<div class="participants-section">
               <h5>Participants:</h5>
               <ul class="participants-list">
@@ -37,13 +37,28 @@ document.addEventListener("DOMContentLoaded", () => {
             </div>`
             : `<p><em>No participants yet</em></p>`;
 
+        const waitlistHTML =
+          details.waitlist_count > 0
+            ? `<div class="participants-section">
+              <h5>Waitlist:</h5>
+              <ol class="waitlist-list">
+                ${details.waitlist
+                  .map((email) => `<li><span class="participant-email">${email}</span></li>`)
+                  .join("")}
+              </ol>
+            </div>`
+            : `<p><em>No students on waitlist</em></p>`;
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <p><strong>Enrolled:</strong> ${details.participant_count}/${details.max_participants}</p>
+          <p><strong>Waitlist:</strong> ${details.waitlist_count}</p>
           <div class="participants-container">
             ${participantsHTML}
+            ${waitlistHTML}
           </div>
         `;
 
@@ -130,8 +145,17 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        const messageByStatus = {
+          enrolled: result.message,
+          waitlisted:
+            result.message +
+            (result.position
+              ? ` (Position #${result.position} on waitlist)`
+              : ""),
+        };
+
+        messageDiv.textContent = messageByStatus[result.status] || result.message;
+        messageDiv.className = result.status === "waitlisted" ? "info" : "success";
         signupForm.reset();
 
         // Refresh activities list to show updated participants

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -92,12 +92,20 @@ section h3 {
   padding-left: 5px;
 }
 
+.participants-section ol {
+  padding-left: 20px;
+}
+
 .participants-section ul li {
   padding: 4px 0;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.participants-section ol li {
+  padding: 4px 0;
 }
 
 /* Remove the bullet point pseudo-element */

--- a/tests/test_waitlist.py
+++ b/tests/test_waitlist.py
@@ -1,0 +1,67 @@
+import unittest
+from copy import deepcopy
+
+from fastapi import HTTPException
+
+from src import app
+
+
+class WaitlistBehaviorTests(unittest.TestCase):
+    def setUp(self):
+        app.activities = deepcopy(app.ACTIVITIES_TEMPLATE)
+
+    def test_full_activity_signup_gets_waitlisted(self):
+        activity_name = "Chess Club"
+        activity = app.activities[activity_name]
+        activity["max_participants"] = len(activity["participants"])
+
+        result = app.signup_for_activity(activity_name, "newstudent@mergington.edu")
+
+        self.assertEqual(result["status"], "waitlisted")
+        self.assertEqual(result["position"], 1)
+        self.assertIn("newstudent@mergington.edu", activity["waitlist"])
+
+    def test_waitlist_auto_promotion_is_fifo(self):
+        activity_name = "Chess Club"
+        activity = app.activities[activity_name]
+        activity["max_participants"] = len(activity["participants"])
+
+        app.signup_for_activity(activity_name, "first@mergington.edu")
+        app.signup_for_activity(activity_name, "second@mergington.edu")
+
+        removed = activity["participants"][0]
+        result = app.unregister_from_activity(activity_name, removed)
+
+        self.assertEqual(result["status"], "promoted")
+        self.assertEqual(result["promoted_email"], "first@mergington.edu")
+        self.assertIn("first@mergington.edu", activity["participants"])
+        self.assertEqual(activity["waitlist"], ["second@mergington.edu"])
+
+    def test_duplicate_signup_rejected_for_participant_or_waitlist(self):
+        activity_name = "Chess Club"
+        activity = app.activities[activity_name]
+        enrolled_email = activity["participants"][0]
+
+        with self.assertRaises(HTTPException) as enrolled_error:
+            app.signup_for_activity(activity_name, enrolled_email)
+        self.assertEqual(enrolled_error.exception.status_code, 400)
+
+        activity["max_participants"] = len(activity["participants"])
+        app.signup_for_activity(activity_name, "queued@mergington.edu")
+
+        with self.assertRaises(HTTPException) as queued_error:
+            app.signup_for_activity(activity_name, "queued@mergington.edu")
+        self.assertEqual(queued_error.exception.status_code, 400)
+
+    def test_activities_payload_contains_counts(self):
+        data = app.get_activities()
+
+        chess = data["Chess Club"]
+        self.assertIn("participant_count", chess)
+        self.assertIn("waitlist_count", chess)
+        self.assertEqual(chess["participant_count"], len(chess["participants"]))
+        self.assertEqual(chess["waitlist_count"], len(chess["waitlist"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce `max_participants` during signup
- add per-activity FIFO waitlist support
- auto-promote first waitlisted student when a participant unregisters
- return structured API statuses (`enrolled`, `waitlisted`, `promoted`, etc.)
- update frontend to display waitlist and counts
- add unit tests for waitlist behavior

## Validation
- `/workspaces/skills-integrate-mcp-with-copilot/.venv/bin/python -m unittest discover -s tests -p 'test_*.py'`

Closes #14